### PR TITLE
Version 0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "autowpdb",
 	"description": "Create and use custom database tables in WordPress.",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"homepage": "https://github.com/Screenfeed/autowpdb",
 	"license": "GPL-2.0",
 	"private": true,

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -24,6 +24,7 @@
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found"/>
 		<exclude name="WordPress.DB.DirectDatabaseQuery.DirectQuery"/>
 		<exclude name="WordPress.DB.DirectDatabaseQuery.NoCaching"/>
+		<exclude name="WordPress.DB.DirectDatabaseQuery.SchemaChange"/>
 		<exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
 		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase"/>
 	</rule>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,5 +6,5 @@ parameters:
     inferPrivatePropertyTypeFromConstructor: true
     paths:
         - %currentWorkingDirectory%/src/
-ignoreErrors:
-    - '#^Function apply_filters(_ref_array)? invoked with \d parameters, \d required\.$#'
+    ignoreErrors:
+        - '#^Function apply_filters(_ref_array)? invoked with \d parameters, \d required\.$#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,3 +6,5 @@ parameters:
     inferPrivatePropertyTypeFromConstructor: true
     paths:
         - %currentWorkingDirectory%/src/
+ignoreErrors:
+    - '#^Function apply_filters(_ref_array)? invoked with \d parameters, \d required\.$#'

--- a/src/CRUD/AbstractCRUD.php
+++ b/src/CRUD/AbstractCRUD.php
@@ -175,7 +175,7 @@ abstract class AbstractCRUD implements CRUDInterface {
 	 */
 	protected function get_placeholder( string $column ): string {
 		$columns = $this->table_definition->get_column_placeholders();
-		return isset( $columns[ $column ] ) ? $columns[ $column ] : '%s';
+		return $columns[ $column ] ?? '%s';
 	}
 
 	/**
@@ -188,7 +188,7 @@ abstract class AbstractCRUD implements CRUDInterface {
 	 */
 	protected function get_default_value( string $column ) { // phpcs:ignore NeutronStandard.Functions.TypeHint.NoReturnType
 		$columns = $this->table_definition->get_column_defaults();
-		return isset( $columns[ $column ] ) ? $columns[ $column ] : null;
+		return $columns[ $column ] ?? null;
 	}
 
 	/**

--- a/src/CRUD/AbstractCRUD.php
+++ b/src/CRUD/AbstractCRUD.php
@@ -32,7 +32,7 @@ abstract class AbstractCRUD implements CRUDInterface {
 	 * @var   TableDefinitionInterface
 	 * @since 0.1
 	 */
-	protected $table_definition;
+	private $table_definition;
 
 	/**
 	 * Stores the list of columns that must be (un)serialized.

--- a/src/CRUD/Basic.php
+++ b/src/CRUD/Basic.php
@@ -39,13 +39,13 @@ class Basic extends AbstractCRUD {
 		$data = $this->prepare_data_for_query( $data );
 
 		// Add default values to missing fields.
-		$data = array_merge( $this->serialize_columns( $this->table->get_column_defaults() ), $data );
+		$data = array_merge( $this->serialize_columns( $this->table_definition->get_column_defaults() ), $data );
 
 		// Remove the auto-increment columns.
 		$data = array_diff_key( $data, $this->get_auto_increment_columns() );
 
 		$wpdb->insert(
-			$this->table->get_table_name(),
+			$this->table_definition->get_table_name(),
 			$data,
 			$this->get_placeholders( $data )
 		);
@@ -69,10 +69,10 @@ class Basic extends AbstractCRUD {
 		$data = $this->prepare_data_for_query( $data );
 
 		// Add default values to missing fields.
-		$data = array_merge( $this->serialize_columns( $this->table->get_column_defaults() ), $data );
+		$data = array_merge( $this->serialize_columns( $this->table_definition->get_column_defaults() ), $data );
 
 		$wpdb->replace(
-			$this->table->get_table_name(),
+			$this->table_definition->get_table_name(),
 			$data,
 			$this->get_placeholders( $data )
 		);
@@ -108,7 +108,7 @@ class Basic extends AbstractCRUD {
 			return null;
 		}
 
-		$table = $this->table->get_table_name();
+		$table = $this->table_definition->get_table_name();
 		$where = $this->prepare_data_for_query( $where );
 
 		if ( ! empty( $where ) ) {
@@ -182,7 +182,7 @@ class Basic extends AbstractCRUD {
 		$where = $this->prepare_data_for_query( $where );
 
 		return $wpdb->update(
-			$this->table->get_table_name(),
+			$this->table_definition->get_table_name(),
 			$data,
 			$where,
 			$this->get_placeholders( $data ),
@@ -213,7 +213,7 @@ class Basic extends AbstractCRUD {
 		$where = $this->prepare_data_for_query( $where );
 
 		return $wpdb->delete(
-			$this->table->get_table_name(),
+			$this->table_definition->get_table_name(),
 			$where,
 			$this->get_placeholders( $where )
 		);

--- a/src/CRUD/Basic.php
+++ b/src/CRUD/Basic.php
@@ -39,13 +39,13 @@ class Basic extends AbstractCRUD {
 		$data = $this->prepare_data_for_query( $data );
 
 		// Add default values to missing fields.
-		$data = array_merge( $this->serialize_columns( $this->table_definition->get_column_defaults() ), $data );
+		$data = array_merge( $this->serialize_columns( $this->get_table_definition()->get_column_defaults() ), $data );
 
 		// Remove the auto-increment columns.
 		$data = array_diff_key( $data, $this->get_auto_increment_columns() );
 
 		$wpdb->insert(
-			$this->table_definition->get_table_name(),
+			$this->get_table_definition()->get_table_name(),
 			$data,
 			$this->get_placeholders( $data )
 		);
@@ -69,10 +69,10 @@ class Basic extends AbstractCRUD {
 		$data = $this->prepare_data_for_query( $data );
 
 		// Add default values to missing fields.
-		$data = array_merge( $this->serialize_columns( $this->table_definition->get_column_defaults() ), $data );
+		$data = array_merge( $this->serialize_columns( $this->get_table_definition()->get_column_defaults() ), $data );
 
 		$wpdb->replace(
-			$this->table_definition->get_table_name(),
+			$this->get_table_definition()->get_table_name(),
 			$data,
 			$this->get_placeholders( $data )
 		);
@@ -108,7 +108,7 @@ class Basic extends AbstractCRUD {
 			return null;
 		}
 
-		$table = $this->table_definition->get_table_name();
+		$table = $this->get_table_definition()->get_table_name();
 		$where = $this->prepare_data_for_query( $where );
 
 		if ( ! empty( $where ) ) {
@@ -182,7 +182,7 @@ class Basic extends AbstractCRUD {
 		$where = $this->prepare_data_for_query( $where );
 
 		return $wpdb->update(
-			$this->table_definition->get_table_name(),
+			$this->get_table_definition()->get_table_name(),
 			$data,
 			$where,
 			$this->get_placeholders( $data ),
@@ -213,7 +213,7 @@ class Basic extends AbstractCRUD {
 		$where = $this->prepare_data_for_query( $where );
 
 		return $wpdb->delete(
-			$this->table_definition->get_table_name(),
+			$this->get_table_definition()->get_table_name(),
 			$where,
 			$this->get_placeholders( $where )
 		);

--- a/src/CRUD/CRUDInterface.php
+++ b/src/CRUD/CRUDInterface.php
@@ -26,13 +26,13 @@ interface CRUDInterface {
 	/** ----------------------------------------------------------------------------------------- */
 
 	/**
-	 * Get the table.
+	 * Get the TableDefinitionInterface object.
 	 *
-	 * @since 0.1
+	 * @since 0.2
 	 *
 	 * @return TableDefinitionInterface
 	 */
-	public function get_table(): TableDefinitionInterface;
+	public function get_table_definition(): TableDefinitionInterface;
 
 	/** ----------------------------------------------------------------------------------------- */
 	/** CREATE ================================================================================== */

--- a/src/DBUtilities.php
+++ b/src/DBUtilities.php
@@ -33,10 +33,10 @@ class DBUtilities {
 	 *
 	 * @param  string       $table_name   The (prefixed) table name. Use `sanitize_table_name()` before passing it to this method.
 	 * @param  string       $schema_query Query representing the table schema.
-	 * @param  array<mixed> $args {
+	 * @param  array<mixed> $args         {
 	 *     Optional arguments.
 	 *
-	 *     @var callable|false $logger Callback to use to log errors. The error message is passed to the callback as 1st argument. False to disable log. Default is 'error_log'.
+	 *     @var callable|false|null $logger Callback to use to log errors. The error message is passed to the callback as 1st argument. False to disable log. Null will default to 'error_log'.
 	 * }
 	 * @return bool                       True on success. False otherwise.
 	 */
@@ -96,10 +96,10 @@ class DBUtilities {
 	 * @source inspired from https://github.com/berlindb/core/blob/734f799e04a9ce86724f2d906b1a6e0fc56fdeb4/table.php#L404-L427.
 	 *
 	 * @param  string       $table_name Full name of the table (with DB prefix). Use `sanitize_table_name()` before passing it to this method.
-	 * @param  array<mixed> $args {
+	 * @param  array<mixed> $args       {
 	 *     Optional arguments.
 	 *
-	 *     @var callable|false $logger Callback to use to log errors. The error message is passed to the callback as 1st argument. False to disable log. Default is 'error_log'.
+	 *     @var callable|false|null $logger Callback to use to log errors. The error message is passed to the callback as 1st argument. False to disable log. Null will default to 'error_log'.
 	 * }
 	 * @return bool                     True on success. False otherwise.
 	 */
@@ -312,7 +312,7 @@ class DBUtilities {
 	 *
 	 * @since 0.2
 	 *
-	 * @param  callable|false $logger Callback to use to log errors. The error message is passed to the callback as 1st argument. False to disable log. Default is 'error_log'.
+	 * @param  callable|false $logger Callback to use to log errors. The error message is passed to the callback as 1st argument. False to disable log.
 	 * @return bool
 	 */
 	protected static function can_log( $logger ): bool { // phpcs:ignore NeutronStandard.Functions.TypeHint.NoArgumentType
@@ -325,6 +325,10 @@ class DBUtilities {
 		}
 
 		if ( ! defined( 'WP_DEBUG_LOG' ) || empty( WP_DEBUG_LOG ) ) {
+			return false;
+		}
+
+		if ( ! is_callable( $logger ) ) {
 			return false;
 		}
 

--- a/src/DBUtilities.php
+++ b/src/DBUtilities.php
@@ -16,6 +16,7 @@ defined( 'ABSPATH' ) || exit; // @phpstan-ignore-line
  *
  * @since 0.1
  * @uses  $GLOBALS['wpdb']
+ * @uses  ABSPATH
  * @uses  dbDelta()
  * @uses  esc_sql()
  * @uses  remove_accents()
@@ -56,7 +57,7 @@ class DBUtilities {
 		}
 
 		if ( ! self::table_exists( $table_name ) ) {
-			// The table does not exists (wtf).
+			// The table does not exist (wtf).
 			empty( $logger ) || call_user_func( $logger, sprintf( 'Creation of the DB table %s failed.', $table_name ) );
 			return false;
 		}

--- a/src/DBUtilities.php
+++ b/src/DBUtilities.php
@@ -17,8 +17,251 @@ defined( 'ABSPATH' ) || exit; // @phpstan-ignore-line
  * @since 0.1
  * @uses  $GLOBALS['wpdb']
  * @uses  dbDelta()
+ * @uses  esc_sql()
+ * @uses  remove_accents()
+ * @uses  sanitize_key()
  */
 class DBUtilities {
+
+	/**
+	 * Create/Upgrade a table in the database.
+	 *
+	 * @since 0.1
+	 *
+	 * @param  string       $table_name   The (prefixed) table name. Use `sanitize_table_name()` before passing it to this method.
+	 * @param  string       $schema_query Query representing the table schema.
+	 * @param  array<mixed> $args {
+	 *     Optional arguments.
+	 *
+	 *     @var callable $logger Callback to use to log errors. The error message is passed to the callback as 1st argument. Default is 'error_log'.
+	 * }
+	 * @return bool                       True on success. False otherwise.
+	 */
+	public static function create_table( string $table_name, string $schema_query, array $args = [] ): bool {
+		global $wpdb;
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+		$wpdb->hide_errors();
+
+		$logger          = isset( $args['logger'] ) ? $args['logger'] : 'error_log';
+		$charset_collate = $wpdb->get_charset_collate();
+
+		dbDelta( "CREATE TABLE `$table_name` ($schema_query) $charset_collate;" );
+
+		if ( ! empty( $wpdb->last_error ) ) {
+			// The query returned an error.
+			empty( $logger ) || call_user_func( $logger, sprintf( 'Error while creating the DB table %s: %s', $table_name, $wpdb->last_error ) );
+			return false;
+		}
+
+		if ( ! self::table_exists( $table_name ) ) {
+			// The table does not exists (wtf).
+			empty( $logger ) || call_user_func( $logger, sprintf( 'Creation of the DB table %s failed.', $table_name ) );
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Tell if the given table exists.
+	 *
+	 * @since 0.1
+	 *
+	 * @param  string $table_name Full name of the table (with DB prefix). Use `sanitize_table_name()` before passing it to this method.
+	 * @return bool
+	 */
+	public static function table_exists( string $table_name ): bool {
+		global $wpdb;
+
+		$table_name = $wpdb->esc_like( $table_name );
+		$query      = "SHOW TABLES LIKE `$table_name`";
+		$result     = $wpdb->get_var( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+		return ( $result === $table_name );
+	}
+
+	/**
+	 * Delete the given table (DROP).
+	 *
+	 * @since  0.2
+	 * @source inspired from https://github.com/berlindb/core/blob/734f799e04a9ce86724f2d906b1a6e0fc56fdeb4/table.php#L404-L427.
+	 *
+	 * @param  string $table_name Full name of the table (with DB prefix). Use `sanitize_table_name()` before passing it to this method.
+	 * @return bool               True on success. False otherwise.
+	 */
+	public static function delete_table( string $table_name ): bool {
+		global $wpdb;
+
+		$query  = "DROP TABLE `$table_name`";
+		$result = $wpdb->query( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+		if ( true !== $result ) {
+			return false;
+		}
+
+		return ! static::table_exists( $table_name );
+	}
+
+	/**
+	 * Reinit the given table (TRUNCATE):
+	 * - Delete all entries,
+	 * - Reinit auto-increment column.
+	 *
+	 * @since  0.2
+	 * @source Inspired from https://github.com/berlindb/core/blob/734f799e04a9ce86724f2d906b1a6e0fc56fdeb4/table.php#L429-L452.
+	 *
+	 * @param  string $table_name Full name of the table (with DB prefix). Use `sanitize_table_name()` before passing it to this method.
+	 * @return bool               True on success. False otherwise.
+	 */
+	public static function reinit_table( string $table_name ): bool {
+		global $wpdb;
+
+		$query  = "TRUNCATE TABLE `$table_name`";
+		$result = $wpdb->query( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+		return true === $result;
+	}
+
+	/**
+	 * Delete all rows from the given table (DELETE FROM):
+	 * - Delete all entries,
+	 * - Do NOT reinit auto-increment column,
+	 * - Return the number of deleted entries,
+	 * - Less performant than reinit.
+	 *
+	 * @since  0.2
+	 * @source Inspired from https://github.com/berlindb/core/blob/734f799e04a9ce86724f2d906b1a6e0fc56fdeb4/table.php#L454-L477.
+	 *
+	 * @param  string $table_name Full name of the table (with DB prefix). Use `sanitize_table_name()` before passing it to this method.
+	 * @return int                Number of deleted rows.
+	 */
+	public static function empty_table( string $table_name ): int {
+		global $wpdb;
+
+		$query = "DELETE FROM `$table_name`";
+
+		return (int) $wpdb->query( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+	}
+
+	/**
+	 * Clone the given table (without its contents).
+	 *
+	 * @since  0.2
+	 * @source Inspired from https://github.com/berlindb/core/blob/master/table.php#L479-L515.
+	 *
+	 * @param  string $table_name     Full name of the table (with DB prefix). Use `sanitize_table_name()` before passing it to this method.
+	 * @param  string $new_table_name Full name of the new table (with DB prefix). Use `sanitize_table_name()` before passing it to this method.
+	 * @return bool                   True on success. False otherwise.
+	 */
+	public static function clone_table( string $table_name, string $new_table_name ): bool {
+		global $wpdb;
+
+		$query  = "CREATE TABLE `$new_table_name` LIKE `$table_name`";
+		$result = $wpdb->query( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+		return true === $result;
+	}
+
+	/**
+	 * Copy the contents of the given table to a new table.
+	 *
+	 * @since  0.2
+	 * @source Inspired from https://github.com/berlindb/core/blob/734f799e04a9ce86724f2d906b1a6e0fc56fdeb4/table.php#L517-L553.
+	 *
+	 * @param  string $table_name     Full name of the table (with DB prefix). Use `sanitize_table_name()` before passing it to this method.
+	 * @param  string $new_table_name Full name of the new table (with DB prefix). Use `sanitize_table_name()` before passing it to this method.
+	 * @return int                    Number of inserted rows.
+	 */
+	public static function copy_table( string $table_name, string $new_table_name ): int {
+		global $wpdb;
+
+		$query = "INSERT INTO `$new_table_name` SELECT * FROM `$table_name`";
+
+		return (int) $wpdb->query( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+	}
+
+	/**
+	 * Count the number of rows in the given table.
+	 *
+	 * @since  0.2
+	 * @source Inspired from https://github.com/berlindb/core/blob/734f799e04a9ce86724f2d906b1a6e0fc56fdeb4/table.php#L555-L578.
+	 *
+	 * @param  string $table_name Full name of the table (with DB prefix). Use `sanitize_table_name()` before passing it to this method.
+	 * @param  string $column     Name of the column to use in `COUNT()`. Optional, default is `*`.
+	 * @return int                Number of rows.
+	 */
+	public static function count_table_rows( string $table_name, string $column = '*' ): int {
+		global $wpdb;
+
+		$prefix = '';
+		$column = trim( $column );
+
+		if ( preg_match( '@^DISTINCT\s+(?<column>[^\s]+)$@i', $column, $matches ) ) {
+			$prefix = 'DISTINCT ';
+			$column = $matches['column'];
+		}
+		if ( '*' !== $column ) {
+			$column = trim( $column, '`\'"' );
+			$column = sprintf( '%s`%s`', $prefix, esc_sql( $column ) );
+		}
+
+		$query = "SELECT COUNT($column) FROM `$table_name`";
+
+		return (int) $wpdb->get_var( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+	}
+
+	/**
+	 * Sanitize a table name string.
+	 * Used to make sure that a table name value meets MySQL expectations.
+	 *
+	 * Applies the following formatting to a string:
+	 * - Trim whitespace,
+	 * - No accents,
+	 * - No special characters,
+	 * - No hyphens,
+	 * - No double underscores,
+	 * - No trailing underscores.
+	 *
+	 * @since  0.2
+	 * @source Inspired from https://github.com/berlindb/core/blob/4d3a93e6036302957523c4f435ea1a67fc632180/base.php#L193-L244.
+	 *
+	 * @param  string $table_name The name of the database table.
+	 * @return string|null        Sanitized database table name. Null on error.
+	 */
+	public static function sanitize_table_name( string $table_name ) { // phpcs:ignore NeutronStandard.Functions.TypeHint.NoReturnType
+		if ( empty( $table_name ) ) {
+			return null;
+		}
+
+		$table_name = trim( $table_name );
+
+		// Only non-accented table names (avoid truncation).
+		$table_name = remove_accents( $table_name );
+
+		// Only lowercase characters, hyphens, and dashes (avoid index corruption).
+		$table_name = sanitize_key( $table_name );
+
+		// Replace hyphens with single underscores.
+		$table_name = str_replace( '-', '_', $table_name );
+
+		// Single underscores only.
+		$table_name = preg_replace( '@_{2,}@', '_', $table_name );
+
+		if ( empty( $table_name ) ) {
+			return null;
+		}
+
+		// Remove trailing underscores.
+		$table_name = trim( $table_name, '_' );
+
+		if ( empty( $table_name ) ) {
+			return null;
+		}
+
+		return $table_name;
+	}
 
 	/**
 	 * Change an array of values into a comma separated list, ready to be used in a `IN ()` clause.
@@ -44,67 +287,5 @@ class DBUtilities {
 	 */
 	public static function quote_string( $value ) { // phpcs:ignore NeutronStandard.Functions.TypeHint.NoArgumentType, NeutronStandard.Functions.TypeHint.NoReturnType
 		return is_numeric( $value ) || ! is_string( $value ) ? $value : "'" . addcslashes( $value, "'" ) . "'";
-	}
-
-	/**
-	 * Create/Upgrade a table in the database.
-	 *
-	 * @since 0.1
-	 *
-	 * @param  string       $table_name   The (prefixed) table name.
-	 * @param  string       $schema_query Query representing the table schema.
-	 * @param  array<mixed> $args {
-	 *     Optional arguments.
-	 *
-	 *     @var callable $logger Callback to use to log errors. The error message is passed to the callback as 1st argument. Default is 'error_log'.
-	 * }
-	 * @return bool                       True on success. False otherwise.
-	 */
-	public static function create_table( string $table_name, string $schema_query, array $args = [] ): bool {
-		global $wpdb;
-
-		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-
-		$wpdb->hide_errors();
-
-		$logger          = isset( $args['logger'] ) ? $args['logger'] : 'error_log';
-		$charset_collate = $wpdb->get_charset_collate();
-
-		dbDelta( "CREATE TABLE $table_name ($schema_query) $charset_collate;" );
-
-		if ( ! empty( $wpdb->last_error ) ) {
-			// The query returned an error.
-			empty( $logger ) || call_user_func( $logger, sprintf( 'Error while creating the DB table %s: %s', $table_name, $wpdb->last_error ) );
-			return false;
-		}
-
-		if ( ! self::table_exists( $table_name ) ) {
-			// The table does not exists (wtf).
-			empty( $logger ) || call_user_func( $logger, sprintf( 'Creation of the DB table %s failed.', $table_name ) );
-			return false;
-		}
-
-		return true;
-	}
-
-	/**
-	 * Tell if the given table exists.
-	 *
-	 * @since 0.1
-	 *
-	 * @param  string $table_name Full name of the table (with DB prefix).
-	 * @return bool
-	 */
-	public static function table_exists( string $table_name ): bool {
-		global $wpdb;
-
-		$result = $wpdb->get_var(
-			$wpdb->prepare(
-				'SHOW TABLES LIKE %s',
-				$wpdb->esc_like( $table_name )
-			)
-		);
-
-		return $result === $table_name;
 	}
 }

--- a/src/DBUtilities.php
+++ b/src/DBUtilities.php
@@ -47,7 +47,7 @@ class DBUtilities {
 
 		$wpdb->hide_errors();
 
-		$logger          = isset( $args['logger'] ) ? $args['logger'] : 'error_log';
+		$logger          = $args['logger'] ?? 'error_log';
 		$charset_collate = $wpdb->get_charset_collate();
 
 		dbDelta( "CREATE TABLE `$table_name` ($schema_query) $charset_collate;" );
@@ -106,7 +106,7 @@ class DBUtilities {
 	public static function delete_table( string $table_name, array $args = [] ): bool {
 		global $wpdb;
 
-		$logger = isset( $args['logger'] ) ? $args['logger'] : 'error_log';
+		$logger = $args['logger'] ?? 'error_log';
 
 		$query  = "DROP TABLE `$table_name`";
 		$result = $wpdb->query( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared

--- a/src/Table.php
+++ b/src/Table.php
@@ -92,7 +92,7 @@ class Table {
 	 * @return bool True on success. False otherwise.
 	 */
 	public function delete( array $args = [] ): bool {
-		return DBUtilities::delete_table( $this->table_definition->get_table_name() );
+		return DBUtilities::delete_table( $this->table_definition->get_table_name(), $args );
 	}
 
 	/**

--- a/src/Table.php
+++ b/src/Table.php
@@ -60,7 +60,7 @@ class Table {
 	 * @param  array<mixed> $args {
 	 *     Optional arguments.
 	 *
-	 *     @var callable $logger Callback to use to log errors. The error message is passed to the callback as 1st argument. Default is 'error_log'.
+	 *     @var callable|false|null $logger Callback to use to log errors. The error message is passed to the callback as 1st argument. False to disable log. Null will default to 'error_log'.
 	 * }
 	 * @return bool True on success. False otherwise.
 	 */
@@ -87,7 +87,7 @@ class Table {
 	 * @param  array<mixed> $args {
 	 *     Optional arguments.
 	 *
-	 *     @var callable $logger Callback to use to log errors. The error message is passed to the callback as 1st argument. Default is 'error_log'.
+	 *     @var callable|false|null $logger Callback to use to log errors. The error message is passed to the callback as 1st argument. False to disable log. Null will default to 'error_log'.
 	 * }
 	 * @return bool True on success. False otherwise.
 	 */

--- a/src/Table.php
+++ b/src/Table.php
@@ -84,9 +84,14 @@ class Table {
 	 *
 	 * @since  0.2
 	 *
+	 * @param  array<mixed> $args {
+	 *     Optional arguments.
+	 *
+	 *     @var callable $logger Callback to use to log errors. The error message is passed to the callback as 1st argument. Default is 'error_log'.
+	 * }
 	 * @return bool True on success. False otherwise.
 	 */
-	public function delete(): bool {
+	public function delete( array $args = [] ): bool {
 		return DBUtilities::delete_table( $this->table_definition->get_table_name() );
 	}
 

--- a/src/Table.php
+++ b/src/Table.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Class to work with a table.
+ *
+ * @package Screenfeed/AutoWPDB
+ */
+
+declare( strict_types=1 );
+
+namespace Screenfeed\AutoWPDB;
+
+use Screenfeed\AutoWPDB\DBUtilities;
+use Screenfeed\AutoWPDB\TableDefinition\TableDefinitionInterface;
+
+defined( 'ABSPATH' ) || exit; // @phpstan-ignore-line
+
+/**
+ * Class to work with a table.
+ *
+ * @since 0.2
+ * @uses  DBUtilities
+ */
+class Table {
+
+	/**
+	 * A TableDefinitionInterface object.
+	 *
+	 * @var   TableDefinitionInterface
+	 * @since 0.2
+	 */
+	protected $table_definition;
+
+	/**
+	 * Get things started.
+	 *
+	 * @since 0.2
+	 *
+	 * @param TableDefinitionInterface $table_definition A TableDefinitionInterface object.
+	 */
+	public function __construct( TableDefinitionInterface $table_definition ) {
+		$this->table_definition = $table_definition;
+	}
+
+	/**
+	 * Get the TableDefinitionInterface object.
+	 *
+	 * @since 0.2
+	 *
+	 * @return TableDefinitionInterface
+	 */
+	public function get_table_definition(): TableDefinitionInterface {
+		return $this->table_definition;
+	}
+
+	/**
+	 * Create/Upgrade the table in the database.
+	 *
+	 * @since 0.2
+	 *
+	 * @param  array<mixed> $args {
+	 *     Optional arguments.
+	 *
+	 *     @var callable $logger Callback to use to log errors. The error message is passed to the callback as 1st argument. Default is 'error_log'.
+	 * }
+	 * @return bool True on success. False otherwise.
+	 */
+	public function create( array $args = [] ): bool {
+		return DBUtilities::create_table( $this->table_definition->get_table_name(), $this->table_definition->get_table_schema(), $args );
+	}
+
+	/**
+	 * Tell if the table exists.
+	 *
+	 * @since 0.2
+	 *
+	 * @return bool
+	 */
+	public function exists(): bool {
+		return DBUtilities::table_exists( $this->table_definition->get_table_name() );
+	}
+
+	/**
+	 * Delete the table (DROP).
+	 *
+	 * @since  0.2
+	 *
+	 * @return bool True on success. False otherwise.
+	 */
+	public function delete(): bool {
+		return DBUtilities::delete_table( $this->table_definition->get_table_name() );
+	}
+
+	/**
+	 * Reinit the table (TRUNCATE):
+	 * - Delete all entries,
+	 * - Reinit auto-increment column.
+	 *
+	 * @since  0.2
+	 *
+	 * @return bool True on success. False otherwise.
+	 */
+	public function reinit(): bool {
+		return DBUtilities::reinit_table( $this->table_definition->get_table_name() );
+	}
+
+	/**
+	 * Delete all rows from the table (DELETE FROM):
+	 * - Delete all entries,
+	 * - Do NOT reinit auto-increment column,
+	 * - Return the number of deleted entries,
+	 * - Less performant than reinit.
+	 *
+	 * @since  0.2
+	 *
+	 * @return int Number of deleted rows.
+	 */
+	public function empty(): int {
+		return DBUtilities::empty_table( $this->table_definition->get_table_name() );
+	}
+
+	/**
+	 * Clone the table (without its contents).
+	 *
+	 * @since  0.2
+	 *
+	 * @param  string $new_table_name Full name of the new table (with DB prefix).
+	 * @return bool                   True on success. False otherwise.
+	 */
+	public function clone_to( string $new_table_name ): bool {
+		$new_table_name = DBUtilities::sanitize_table_name( $new_table_name );
+
+		if ( empty( $new_table_name ) ) {
+			return false;
+		}
+
+		return DBUtilities::clone_table( $this->table_definition->get_table_name(), $new_table_name );
+	}
+
+	/**
+	 * Copy the contents of the table to a new table.
+	 *
+	 * @since  0.2
+	 *
+	 * @param  string $new_table_name Full name of the new table (with DB prefix).
+	 * @return int                    Number of inserted rows.
+	 */
+	public function copy_to( string $new_table_name ): int {
+		$new_table_name = DBUtilities::sanitize_table_name( $new_table_name );
+
+		if ( empty( $new_table_name ) ) {
+			return 0;
+		}
+
+		return DBUtilities::copy_table( $this->table_definition->get_table_name(), $new_table_name );
+	}
+
+	/**
+	 * Count the number of rows in the table.
+	 *
+	 * @since  0.2
+	 *
+	 * @param  string $column Name of the column to use in `COUNT()`. Optional, default is `*`.
+	 * @return int            Number of rows.
+	 */
+	public function count( string $column = '*' ): int {
+		return DBUtilities::count_table_rows( $this->table_definition->get_table_name(), $column );
+	}
+}

--- a/src/TableUpgrader.php
+++ b/src/TableUpgrader.php
@@ -18,7 +18,6 @@ defined( 'ABSPATH' ) || exit; // @phpstan-ignore-line
  * Class that creates or upgrades a table automatically.
  *
  * @since 0.1
- * @uses  DBUtilities
  * @uses  add_action()
  * @uses  is_multisite()
  * @uses  get_site_option()

--- a/src/TableUpgrader.php
+++ b/src/TableUpgrader.php
@@ -102,7 +102,7 @@ class TableUpgrader {
 		if ( ! $this->table_is_up_to_date() ) {
 			/**
 			 * The option doesn't exist or is not up-to-date: we must upgrade the table before declaring it ready.
-			 * See self::maybe_upgrade_table() for the upgrade.
+			 * See $this->maybe_upgrade_table() for the upgrade.
 			 */
 			return;
 		}
@@ -124,17 +124,6 @@ class TableUpgrader {
 		}
 
 		add_action( $this->upgrade_hook, [ $this, 'maybe_upgrade_table' ], $this->upgrade_hook_prio );
-	}
-
-	/**
-	 * Tell if the table is ready to be used.
-	 *
-	 * @since 0.1
-	 *
-	 * @return bool
-	 */
-	public function table_is_ready(): bool {
-		return $this->table_ready;
 	}
 
 	/** ----------------------------------------------------------------------------------------- */
@@ -294,6 +283,41 @@ class TableUpgrader {
 		// Table successfully created/upgraded.
 		$this->set_table_ready();
 		$this->update_db_version();
+	}
+
+	/** ----------------------------------------------------------------------------------------- */
+	/** TABLE DELETION ========================================================================== */
+	/** ----------------------------------------------------------------------------------------- */
+
+	/**
+	 * Delete the table from the database.
+	 *
+	 * @since 0.1
+	 *
+	 * @return void
+	 */
+	public function delete_table() {
+		if ( ! $this->table->delete() ) {
+			return;
+		}
+
+		$this->set_table_not_ready();
+		$this->delete_db_version();
+	}
+
+	/** ----------------------------------------------------------------------------------------- */
+	/** TABLE READY ============================================================================= */
+	/** ----------------------------------------------------------------------------------------- */
+
+	/**
+	 * Tell if the table is ready to be used.
+	 *
+	 * @since 0.1
+	 *
+	 * @return bool
+	 */
+	public function table_is_ready(): bool {
+		return $this->table_ready;
 	}
 
 	/**

--- a/src/TableUpgrader.php
+++ b/src/TableUpgrader.php
@@ -74,8 +74,8 @@ class TableUpgrader {
 	/**
 	 * Callback to use to log errors. The error message is passed to the callback as 1st argument. False to disable log. Null will default to 'error_log'.
 	 *
-	 * @var callable|false|null
-	 * @since 0.1
+	 * @var   callable|false|null
+	 * @since 0.2
 	 */
 	protected $logger;
 
@@ -308,7 +308,7 @@ class TableUpgrader {
 	/**
 	 * Delete the table from the database.
 	 *
-	 * @since 0.1
+	 * @since 0.2
 	 *
 	 * @return void
 	 */

--- a/src/TableUpgrader.php
+++ b/src/TableUpgrader.php
@@ -289,7 +289,6 @@ class TableUpgrader {
 		if ( ! $this->table->create() ) {
 			// Failure.
 			$this->set_table_not_ready();
-			$this->delete_db_version();
 			return;
 		}
 

--- a/src/TableUpgrader.php
+++ b/src/TableUpgrader.php
@@ -72,7 +72,7 @@ class TableUpgrader {
 	protected $upgrade_hook_prio;
 
 	/**
-	 * Callback to use to log errors. The error message is passed to the callback as 1st argument. False to disable log. Default is 'error_log'.
+	 * Callback to use to log errors. The error message is passed to the callback as 1st argument. False to disable log. Null will default to 'error_log'.
 	 *
 	 * @var callable|false|null
 	 * @since 0.1


### PR DESCRIPTION
Main changes:
- `DBUtilities`:
  - Improved methods a bit, like wrapping table names into quotes in the queries.
  - New methods: `delete_table()`, `reinit_table()`, `empty_table()`, `clone_table()`, `copy_table()`, `count_table_rows()`, and `sanitize_table_name()`. This is inspired by what BerlinDB does.

- New class `Table`: this class basically combines `TableDefinitionInterface` and `DBUtilities`, to be easier to work with.

- `CRUD` classes:
  - Renamed `get_table()` into `get_table_definition()` to prevent confusion between the classes `Table` and the interface `TableDefinitionInterface`.
  - `AbstractCRUD`: the property `table_definition` is now private. Use `get_table_definition()` in sub-classes instead.

- `AbstractTableDefinition`:
  - `get_table_name()` now uses `DBUtilities::sanitize_table_name()`.
  - New method `jsonSerialize()` (from the interface `JsonSerializable`): returns an array containing the method results. The array keys are `table_version`, `table_short_name`, `table_name`, `table_is_global`, `primary_key`, `column_placeholders`, `column_defaults`, and `table_schema`. `json_encode()` can be used directly on the class instance now.
  - New magic method `__toString()`: this will simply `json_encode()` the class.

- `TableUpgrader`:
  - Signature change: a `Table` object must be used as first argument instead of `TableDefinitionInterface`.
  - New methods `table_is_allowed_to_upgrade()` and `delete_table()`.
  - The table version is not deleted from the DB anymore if the table upgrade failed.